### PR TITLE
Avoid absender error if strasse not set

### DIFF
--- a/erica/erica_legacy/elster_xml/grundsteuer/elster_data_representation.py
+++ b/erica/erica_legacy/elster_xml/grundsteuer/elster_data_representation.py
@@ -154,10 +154,13 @@ class EVorsatz:
     def __init__(self, input_data: GrundsteuerPayload):
         self.Unterfallart = "88"  # Grundsteuer
         self.Vorgang = "01"  # Veranlagung
-        self.Zeitraum = "2022"  # TODO require on input?
+        self.Zeitraum = "2022"
         self.AbsName = input_data.eigentuemer.person[0].persoenliche_angaben.vorname + " " + \
                        input_data.eigentuemer.person[0].persoenliche_angaben.name
-        self.AbsStr = input_data.eigentuemer.person[0].adresse.strasse
+        if input_data.eigentuemer.person[0].adresse.strasse:
+            self.AbsStr = input_data.eigentuemer.person[0].adresse.strasse
+        else:
+            self.AbsStr = input_data.eigentuemer.person[0].adresse.postfach
         self.AbsPlz = input_data.eigentuemer.person[0].adresse.plz
         self.AbsOrt = input_data.eigentuemer.person[0].adresse.ort
         self.Copyright = "(C) 2022 DigitalService GmbH des Bundes"

--- a/tests/erica_legacy/elster_xml/grundsteuer/test_elster_data_representation.py
+++ b/tests/erica_legacy/elster_xml/grundsteuer/test_elster_data_representation.py
@@ -1,7 +1,4 @@
 from xml.etree import ElementTree
-
-import pytest
-
 from erica.erica_legacy.elster_xml.common.basic_xml_data_representation import EXml
 from erica.erica_legacy.elster_xml.common.xml_conversion import convert_object_to_xml
 from erica.erica_legacy.elster_xml.grundsteuer.elster_data_representation import ERueckuebermittlung, EVorsatz, \
@@ -298,6 +295,15 @@ class TestEVorsatz:
         assert result.StNr is None
         assert result.Aktenzeichen == "520850353038893"
         assert result.OrdNrArt == "A"
+
+    def test_if_no_street_given_then_attributes_set_postfach_for_AbsStr(self):
+        grundsteuer_obj = SampleGrundsteuerData().parse()
+        grundsteuer_obj.eigentuemer.person[0].adresse.strasse = None
+        grundsteuer_obj.eigentuemer.person[0].adresse.postfach = "123456"
+
+        result = EVorsatz(grundsteuer_obj)
+
+        assert result.AbsStr == "123456"
 
 
 class TestEGrundsteuerSpecifics:


### PR DESCRIPTION
# Short Description
- As for eigentuemer it is not required to have the street set - instead it is either required to set the street or the postfach - we cannot simply set the AbsStr for the Absender to the eigentuemer street
- The not-so-pretty-but-in-my-head-completely-fine-solution for this is to in that case just set the AbsStr to the postfach. Especially since we learned that those are historic fields that aren't actually used for anything anymore at Elster's side.

# Changes
- Set AbsStr to postfach if street not set

# Feedback
- Except from it being non-intuitive, do you see any problems with this?

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
