### PR TITLE
Expose FSC already revoked error to clients

### DIFF
--- a/erica/erica_legacy/pyeric/eric_errors.py
+++ b/erica/erica_legacy/pyeric/eric_errors.py
@@ -13,6 +13,7 @@ _ERIC_CUSTOM_ERROR_CODES = {
     5: "ELSTER_REQUEST_ID_UNKNOWN",
     6: "INVALID_BUFA_NUMBER",
     7: "INVALID_TAX_NUMBER",
+    8: "ALREADY_REVOKED",
 }
 
 _ERIC_GLOBAL_VALIDATION_ERRORS = {
@@ -419,6 +420,11 @@ class EricAlreadyRevokedError(EricTransferError):
     """Exception raised in case the unlock code was already revoked.
     """
     ERROR_CODE = 11
+
+    # Overwrite initaliser to set custom res_code
+    def __init__(self, eric_response=None, server_response=None, server_err_msg=None):
+        # This error always has the res_code 8
+        super().__init__(8, eric_response, server_response, server_err_msg)
 
     def __str__(self):
         return "The request for the request code has already been revoked"

--- a/erica/erica_legacy/pyeric/eric_errors.py
+++ b/erica/erica_legacy/pyeric/eric_errors.py
@@ -10,10 +10,10 @@ _ERIC_SUCCESS_CODE = {
 _ERIC_CUSTOM_ERROR_CODES = {
     1: "NULL_POINTER_RETURNED",
     3: "ALREADY_OPEN_UNLOCK_CODE_REQUEST",
+    4: "ALREADY_REVOKED_UNLOCK_CODE",
     5: "ELSTER_REQUEST_ID_UNKNOWN",
     6: "INVALID_BUFA_NUMBER",
     7: "INVALID_TAX_NUMBER",
-    8: "ALREADY_REVOKED",
 }
 
 _ERIC_GLOBAL_VALIDATION_ERRORS = {
@@ -422,9 +422,9 @@ class EricAlreadyRevokedError(EricTransferError):
     ERROR_CODE = 11
 
     # Overwrite initaliser to set custom res_code
-    def __init__(self, res_code=None, eric_response=None, server_response=None, server_err_msg=None):
+    def __init__(self, eric_response=None, server_response=None, server_err_msg=None):
         # This error always has the res_code 8
-        super().__init__(8, eric_response, server_response, server_err_msg)
+        super().__init__(4, eric_response, server_response, server_err_msg)
 
     def __str__(self):
         return "The request for the request code has already been revoked"
@@ -507,7 +507,7 @@ def _create_validation_error(rescode, eric_response):
 def _create_transfer_error(rescode, eric_response, server_response, server_err_msg=None):
     if rescode == 610101292 and server_err_msg and is_error_in_server_err_msg(server_err_msg.get('NDH_ERR_XML'),
                                                                               '371015213'):
-        raise EricAlreadyRevokedError(rescode, eric_response, server_response, server_err_msg)
+        raise EricAlreadyRevokedError(eric_response, server_response, server_err_msg)
     elif server_response and rescode in _FSC_ALREADY_REQUESTED_ERRORS and \
             ("Es besteht bereits ein offener Antrag auf Erteilung einer Berechtigung zum Datenabruf"
              in server_response.decode() or

--- a/erica/erica_legacy/pyeric/eric_errors.py
+++ b/erica/erica_legacy/pyeric/eric_errors.py
@@ -422,7 +422,7 @@ class EricAlreadyRevokedError(EricTransferError):
     ERROR_CODE = 11
 
     # Overwrite initaliser to set custom res_code
-    def __init__(self, eric_response=None, server_response=None, server_err_msg=None):
+    def __init__(self, res_code=None, eric_response=None, server_response=None, server_err_msg=None):
         # This error always has the res_code 8
         super().__init__(8, eric_response, server_response, server_err_msg)
 


### PR DESCRIPTION
# Short Description
- When implementing the re-requesting of FSCs in Grundsteuer, I was thinking about this and noticed that we ar enot exposing the specific "AlreadyRequestedFSC" error to clients. I think there's no harm in that?

# Changes
- Explicitly add AlreadyRevokedError to possible error codes

# Feedback
- Do you see a reason we shouldn't do this?

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
