### PR TITLE
Add optional tax_year to unlock_code_request

### DIFF
--- a/contract_tests/test_integration_queue.py
+++ b/contract_tests/test_integration_queue.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -421,6 +422,15 @@ class TestV2UnlockCodeRequest:
     endpoint = "/v2/fsc/request"
 
     def test_if_post_with_full_data_then_return_201_and_location_with_valid_uuid(self, full_unlock_code_request_data):
+        response = requests.post(ERICA_TESTING_URL + self.endpoint,
+                                 data=json.dumps(full_unlock_code_request_data, default=str))
+        assert response.status_code == 201
+        location = response.headers['Location'].split("/")
+        assert "/" + location[0] + "/" + location[1] + "/" + location[2] == self.endpoint
+        assert is_valid_uuid(location[3])
+
+    def test_if_post_with_full_data_and_tax_year_then_return_201_and_location_with_valid_uuid(self, full_unlock_code_request_data):
+        full_unlock_code_request_data["tax_year"] = "3000"
         response = requests.post(ERICA_TESTING_URL + self.endpoint,
                                  data=json.dumps(full_unlock_code_request_data, default=str))
         assert response.status_code == 201

--- a/erica/application/FreischaltCode/FreischaltCode.py
+++ b/erica/application/FreischaltCode/FreischaltCode.py
@@ -8,12 +8,13 @@ from erica.application.base_dto import BaseDto
 
 # Input
 from erica.domain.Shared.tax_id_number import TaxIdNumber
+from erica.erica_legacy.elster_xml.elster_xml_generator import VERANLAGUNGSJAHR
 
 
 class FreischaltCodeRequestPayloadDto(BaseDto):
     tax_id_number: TaxIdNumber
     date_of_birth: date
-    tax_year: str = "2021"
+    tax_year: str = str(VERANLAGUNGSJAHR)
 
 
 class FreischaltCodeActivatePayloadDto(BaseDto):

--- a/erica/application/FreischaltCode/FreischaltCode.py
+++ b/erica/application/FreischaltCode/FreischaltCode.py
@@ -8,13 +8,12 @@ from erica.application.base_dto import BaseDto
 
 # Input
 from erica.domain.Shared.tax_id_number import TaxIdNumber
-from erica.erica_legacy.elster_xml.elster_xml_generator import VERANLAGUNGSJAHR
 
 
 class FreischaltCodeRequestPayloadDto(BaseDto):
     tax_id_number: TaxIdNumber
     date_of_birth: date
-    tax_year: str = str(VERANLAGUNGSJAHR)
+    tax_year: Optional[str]
 
 
 class FreischaltCodeActivatePayloadDto(BaseDto):

--- a/erica/application/FreischaltCode/FreischaltCode.py
+++ b/erica/application/FreischaltCode/FreischaltCode.py
@@ -13,6 +13,7 @@ from erica.domain.Shared.tax_id_number import TaxIdNumber
 class FreischaltCodeRequestPayloadDto(BaseDto):
     tax_id_number: TaxIdNumber
     date_of_birth: date
+    tax_year: str = "2021"
 
 
 class FreischaltCodeActivatePayloadDto(BaseDto):

--- a/erica/domain/FreischaltCode/FreischaltCode.py
+++ b/erica/domain/FreischaltCode/FreischaltCode.py
@@ -3,13 +3,12 @@ from datetime import date
 from typing import Optional
 
 from erica.domain.Shared.BaseDomainModel import BasePayload
-from erica.erica_legacy.elster_xml.elster_xml_generator import VERANLAGUNGSJAHR
 
 
 class FreischaltCodeRequestPayload(BasePayload, ABC):
     tax_id_number: str
     date_of_birth: date
-    tax_year: str = str(VERANLAGUNGSJAHR)
+    tax_year: Optional[str]
 
 
 class FreischaltCodeActivatePayload(BasePayload, ABC):

--- a/erica/domain/FreischaltCode/FreischaltCode.py
+++ b/erica/domain/FreischaltCode/FreischaltCode.py
@@ -8,6 +8,7 @@ from erica.domain.Shared.BaseDomainModel import BasePayload
 class FreischaltCodeRequestPayload(BasePayload, ABC):
     tax_id_number: str
     date_of_birth: date
+    tax_year: str = "2021"
 
 
 class FreischaltCodeActivatePayload(BasePayload, ABC):

--- a/erica/domain/FreischaltCode/FreischaltCode.py
+++ b/erica/domain/FreischaltCode/FreischaltCode.py
@@ -3,12 +3,13 @@ from datetime import date
 from typing import Optional
 
 from erica.domain.Shared.BaseDomainModel import BasePayload
+from erica.erica_legacy.elster_xml.elster_xml_generator import VERANLAGUNGSJAHR
 
 
 class FreischaltCodeRequestPayload(BasePayload, ABC):
     tax_id_number: str
     date_of_birth: date
-    tax_year: str = "2021"
+    tax_year: str = str(VERANLAGUNGSJAHR)
 
 
 class FreischaltCodeActivatePayload(BasePayload, ABC):

--- a/erica/erica_legacy/elster_xml/elster_xml_generator.py
+++ b/erica/erica_legacy/elster_xml/elster_xml_generator.py
@@ -274,7 +274,8 @@ def _add_vast_request_xml_nutzdaten(xml_top, user_data):
     veranlagungszeitraum_xml = SubElement(spez_recht_antrag_xml, 'Veranlagungszeitraum')
     SubElement(veranlagungszeitraum_xml, 'Unbeschraenkt').text = 'false'
     veranlagungsjahre_xml = SubElement(veranlagungszeitraum_xml, 'Veranlagungsjahre')
-    SubElement(veranlagungsjahre_xml, 'Jahr').text = user_data['tax_year']
+    SubElement(veranlagungsjahre_xml, 'Jahr').text = user_data.get('tax_year') \
+        if user_data.get('tax_year') else str(VERANLAGUNGSJAHR)
 
 
 def _add_vast_activation_xml_nutzdaten(xml_top, user_data):

--- a/erica/erica_legacy/elster_xml/elster_xml_generator.py
+++ b/erica/erica_legacy/elster_xml/elster_xml_generator.py
@@ -274,7 +274,7 @@ def _add_vast_request_xml_nutzdaten(xml_top, user_data):
     veranlagungszeitraum_xml = SubElement(spez_recht_antrag_xml, 'Veranlagungszeitraum')
     SubElement(veranlagungszeitraum_xml, 'Unbeschraenkt').text = 'false'
     veranlagungsjahre_xml = SubElement(veranlagungszeitraum_xml, 'Veranlagungsjahre')
-    SubElement(veranlagungsjahre_xml, 'Jahr').text = str(VERANLAGUNGSJAHR)
+    SubElement(veranlagungsjahre_xml, 'Jahr').text = user_data['tax_year']
 
 
 def _add_vast_activation_xml_nutzdaten(xml_top, user_data):

--- a/erica/erica_legacy/request_processing/eric_mapper.py
+++ b/erica/erica_legacy/request_processing/eric_mapper.py
@@ -164,7 +164,7 @@ class EstEricMapping(Stmind):
 class UnlockCodeRequestEricMapper(BaseModel):
     tax_id_number: str
     date_of_birth: str
-    tax_year: str
+    tax_year: Optional[str]
 
     @validator('date_of_birth', pre=True)
     def convert_datetime_to_y_m_d(cls, v):

--- a/erica/erica_legacy/request_processing/eric_mapper.py
+++ b/erica/erica_legacy/request_processing/eric_mapper.py
@@ -164,6 +164,7 @@ class EstEricMapping(Stmind):
 class UnlockCodeRequestEricMapper(BaseModel):
     tax_id_number: str
     date_of_birth: str
+    tax_year: str
 
     @validator('date_of_birth', pre=True)
     def convert_datetime_to_y_m_d(cls, v):

--- a/erica/erica_legacy/request_processing/erica_input/v1/erica_input.py
+++ b/erica/erica_legacy/request_processing/erica_input/v1/erica_input.py
@@ -221,7 +221,7 @@ class EstData(BaseModel):
 class UnlockCodeRequestData(BaseModel):
     tax_id_number: str = Field(alias='idnr')
     date_of_birth: date = Field(alias='dob')
-    tax_year: str = Field(default='2021', alias='taxYear')
+    tax_year: str = Field(default=str(VERANLAGUNGSJAHR), alias='taxYear')
 
 
 class UnlockCodeActivationData(BaseModel):

--- a/erica/erica_legacy/request_processing/erica_input/v1/erica_input.py
+++ b/erica/erica_legacy/request_processing/erica_input/v1/erica_input.py
@@ -221,7 +221,7 @@ class EstData(BaseModel):
 class UnlockCodeRequestData(BaseModel):
     tax_id_number: str = Field(alias='idnr')
     date_of_birth: date = Field(alias='dob')
-    tax_year: str = Field(default=str(VERANLAGUNGSJAHR), alias='taxYear')
+    tax_year: Optional[str] = Field(alias='taxYear')
 
 
 class UnlockCodeActivationData(BaseModel):

--- a/erica/erica_legacy/request_processing/erica_input/v1/erica_input.py
+++ b/erica/erica_legacy/request_processing/erica_input/v1/erica_input.py
@@ -221,6 +221,7 @@ class EstData(BaseModel):
 class UnlockCodeRequestData(BaseModel):
     tax_id_number: str = Field(alias='idnr')
     date_of_birth: date = Field(alias='dob')
+    tax_year: str = Field(default='2021', alias='taxYear')
 
 
 class UnlockCodeActivationData(BaseModel):

--- a/tests/erica_legacy/elster_xml/test_elster_xml_generator.py
+++ b/tests/erica_legacy/elster_xml/test_elster_xml_generator.py
@@ -958,7 +958,8 @@ class TestVastRequest(unittest.TestCase):
         self.expected_antrag_version = '3'
         self.valid_user_data = {
             'tax_id_number': '04452397687',
-            'date_of_birth': '1985-01-01'
+            'date_of_birth': '1985-01-01',
+            'tax_year': '2021'
         }
 
     @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
@@ -984,7 +985,7 @@ class TestVastRequest(unittest.TestCase):
         xml_string = _pretty(xml_top)
 
         self.assertEqual('false', xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Unbeschraenkt').text)
-        self.assertEqual(str(TEST_EST_VERANLAGUNGSJAHR), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
+        self.assertEqual(str(self.valid_user_data['tax_year']), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
         self.assertEqual(f'{_BEANTRAGUNGSJAHR}-12-31', xml_top.find('.//SpezRechtAntrag/GueltigBis').text)
         self.assertIn('<SpezRechtAntrag version="' + self.expected_antrag_version + '">', xml_string)
         self.assertIn(
@@ -992,6 +993,14 @@ class TestVastRequest(unittest.TestCase):
             "".join(xml_string.split()))
         self.assertIn(f"<DatenabruferMail>{get_settings().testing_email_address}</DatenabruferMail>",
                       "".join(xml_string.split()))
+
+    def test_set_tax_year_correctly(self):
+        xml_top = Element('top')
+        input = copy.deepcopy(self.valid_user_data)
+        input["tax_year"] = "3000"
+        _add_vast_request_xml_nutzdaten(xml_top, input)
+
+        self.assertEqual("3000", xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
 
     @freeze_time("2020-05-04")
     def test_compute_valid_until_date_returns_correct_date_if_during_a_year(self):

--- a/tests/erica_legacy/elster_xml/test_elster_xml_generator.py
+++ b/tests/erica_legacy/elster_xml/test_elster_xml_generator.py
@@ -994,13 +994,20 @@ class TestVastRequest(unittest.TestCase):
         self.assertIn(f"<DatenabruferMail>{get_settings().testing_email_address}</DatenabruferMail>",
                       "".join(xml_string.split()))
 
-    def test_set_tax_year_correctly(self):
+    def test_if_tax_year_given_then_set_tax_year_correctly(self):
         xml_top = Element('top')
         input_data = copy.deepcopy(self.valid_user_data)
         input_data["tax_year"] = "3000"
         _add_vast_request_xml_nutzdaten(xml_top, input_data)
 
         self.assertEqual("3000", xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
+
+    def test_if_tax_year_not_given_then_set_tax_year_correctly(self):
+        xml_top = Element('top')
+        input_data = copy.deepcopy(self.valid_user_data)
+        _add_vast_request_xml_nutzdaten(xml_top, input_data)
+
+        self.assertEqual(str(TEST_EST_VERANLAGUNGSJAHR), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
 
     @freeze_time("2020-05-04")
     def test_compute_valid_until_date_returns_correct_date_if_during_a_year(self):

--- a/tests/erica_legacy/elster_xml/test_elster_xml_generator.py
+++ b/tests/erica_legacy/elster_xml/test_elster_xml_generator.py
@@ -996,9 +996,9 @@ class TestVastRequest(unittest.TestCase):
 
     def test_set_tax_year_correctly(self):
         xml_top = Element('top')
-        input = copy.deepcopy(self.valid_user_data)
-        input["tax_year"] = "3000"
-        _add_vast_request_xml_nutzdaten(xml_top, input)
+        input_data = copy.deepcopy(self.valid_user_data)
+        input_data["tax_year"] = "3000"
+        _add_vast_request_xml_nutzdaten(xml_top, input_data)
 
         self.assertEqual("3000", xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
 

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -342,7 +342,7 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
 class TestUnlockCodeRequestGenerateFullXml(unittest.TestCase):
 
     def test_if_dob_date_given_then_call_generate_full_xml_with_unlock_code_eric_mapping(self):
-        unlock_code_eric_mapping = UnlockCodeRequestEricMapper(tax_id_number="09952417688", date_of_birth=date(1969, 7, 20))
+        unlock_code_eric_mapping = UnlockCodeRequestEricMapper(tax_id_number="09952417688", date_of_birth=date(1969, 7, 20), tax_year="2021")
 
         created_request = UnlockCodeRequestController(UnlockCodeRequestData(idnr="09952417688", dob=date(1969, 7, 20)))
 

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -342,7 +342,7 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
 class TestUnlockCodeRequestGenerateFullXml(unittest.TestCase):
 
     def test_if_dob_date_given_then_call_generate_full_xml_with_unlock_code_eric_mapping(self):
-        unlock_code_eric_mapping = UnlockCodeRequestEricMapper(tax_id_number="09952417688", date_of_birth=date(1969, 7, 20), tax_year="2021")
+        unlock_code_eric_mapping = UnlockCodeRequestEricMapper(tax_id_number="09952417688", date_of_birth=date(1969, 7, 20))
 
         created_request = UnlockCodeRequestController(UnlockCodeRequestData(idnr="09952417688", dob=date(1969, 7, 20)))
 


### PR DESCRIPTION
# Short Description
- Users of grundsteuer are confused because in their FSC letter it says "Veranlagungsjahr: 2021", although they ant to do the declaration for 2022 - to be able to configure that, I introduced an optional input parameter to differ from "2021" - this way it should work as normal until you provide a different tax_year.

# Changes
- Add tax_year to all unlock_code_request input tapes
- Set tax_year in unlock_code_request XML

# Feedback
- I'm slightly confused if I introduced the default value in the right places. That I have to alter a type a full *three* times seems quite a lot to me and I' not sure I did this correctly.
- Do you see a good place to test that the input tax_year in the end results in the XML and that the default is set correctly? I'm not really satisfied with the test coverage on this one.

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
