### PR TITLE
Only log elster error code of transfer errors

### DIFF
--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -10,7 +10,8 @@ from erica.domain.repositories import base_repository_interface
 from erica.domain.Shared.Status import Status
 from erica.domain.erica_request.erica_request import EricaRequest
 from erica.domain.Shared.BaseDomainModel import BasePayload
-from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful, get_error_codes_from_server_err_msg
+from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful, get_error_codes_from_server_err_msg, \
+    EricTransferError
 from erica.infrastructure.sqlalchemy.repositories.base_repository import EntityNotFoundError
 
 
@@ -52,7 +53,7 @@ def perform_job(request_id: UUID, repository: base_repository_interface, service
         except EricProcessNotSuccessful as e:
             error_response = e.generate_error_response(True)
             transfer_errors_xml = error_response.get('server_err_msg').get('NDH_ERR_XML') if error_response.get('server_err_msg') else None
-            if transfer_errors_xml:
+            if transfer_errors_xml and e.__class__ is EricTransferError:
                 logger.warning(
                     f"Job failed: {entity}. Got error: {error_response.get('code')}. "
                     f"TransferErrors: {get_error_codes_from_server_err_msg(transfer_errors_xml)}",


### PR DESCRIPTION
# Short Description
- Previously, we logged the Elster return code of all TransferErrors, resulting in some errors being logged twice

# Changes
- Check the concrete EricTransferError class and only log for that
- Add tests for both cases

# Feedback
- Really more a SHOW @JulianRoesner 

# How to review this Pull Request
[Link to Confluence](https://digitalservicebund.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
