### PR TITLE
Make SteuerID in grundsteuer input optional.

### DIFF
--- a/erica/worker/elster_xml/grundsteuer/elster_eigentuemer.py
+++ b/erica/worker/elster_xml/grundsteuer/elster_eigentuemer.py
@@ -60,7 +60,7 @@ class EPersonData:
     E7404527: Optional[str]
     E7404522: str
     E7414601: Optional[str]
-    E7404519: str
+    E7404519: Optional[str]
     Anteil: EAnteil
     Ges_Vertreter: Optional[EGesetzlicherVertreter]
 

--- a/erica/worker/request_processing/grundsteuer_request_controller.py
+++ b/erica/worker/request_processing/grundsteuer_request_controller.py
@@ -1,5 +1,6 @@
 import base64
 
+from erica.config import get_settings
 from erica.worker.pyeric.check_elster_request_id import tax_id_number_is_test_id_number
 from erica.worker.pyeric.pyeric_controller import GrundsteuerPyericProcessController
 from erica.worker.pyeric.pyeric_response import PyericResponse
@@ -16,7 +17,7 @@ class GrundsteuerRequestController(TransferticketRequestController):
     def _is_testmerker_used(self):
         if len(self.input_data.eigentuemer.person) >= 1 and self.input_data.eigentuemer.person[0].steuer_id:
             return tax_id_number_is_test_id_number(self.input_data.eigentuemer.person[0].steuer_id)
-        return True
+        return get_settings().use_testmerker
 
     def generate_full_xml(self, use_testmerker):
         """ Constructs the complete XML for the grundsteuer use case. """


### PR DESCRIPTION
The requirements are specified in https://steuerlotse.atlassian.net/browse/STL-2902?focusedCommentId=13022 

To recap:

SteuerID given: test/real submissions are determined using the 0 prefix (same as before).

SteuerID not given: environment-specific config determines whether to mark the submission as test (false on production, true on staging)
