### PR TITLE
Fix person validation on missing SteuerID.

### DIFF
--- a/erica/api/dto/grundsteuer_input_eigentuemer.py
+++ b/erica/api/dto/grundsteuer_input_eigentuemer.py
@@ -3,8 +3,10 @@ from enum import Enum
 from typing import Optional, List
 
 from pydantic import validator
+
 from erica.api.dto.base_dto import CamelCaseModel
-from erica.worker.pyeric.check_elster_request_id import tax_id_number_is_test_id_number
+from erica.worker.pyeric.check_elster_request_id import tax_id_number_is_none_or_test_id_number, \
+    tax_id_number_is_none_or_real_id_number
 
 
 class Anrede(str, Enum):
@@ -79,13 +81,14 @@ class Eigentuemer(CamelCaseModel):
         return v
 
     @validator("person")
-    def must_have_all_test_ids_or_no_test_ids(cls, v, values):
-        if not(all([tax_id_number_is_test_id_number(person.steuer_id) for person in v]) or all([not tax_id_number_is_test_id_number(person.steuer_id) for person in v])):
+    def must_have_all_test_ids_or_no_test_ids(cls, v):
+        if not (all([tax_id_number_is_none_or_test_id_number(person.steuer_id) for person in v]) or all(
+                [tax_id_number_is_none_or_real_id_number(person.steuer_id) for person in v])):
             raise ValueError('all eigentuemer need to use either real or test tax id numbers')
         return v
 
     @validator("person")
-    def must_not_be_empty(cls, v, values):
+    def must_not_be_empty(cls, v):
         if len(v) < 1:
             raise ValueError('at least one eigentuemer needs to be set')
         return v

--- a/erica/worker/pyeric/check_elster_request_id.py
+++ b/erica/worker/pyeric/check_elster_request_id.py
@@ -35,6 +35,14 @@ def tax_id_number_is_test_id_number(tax_id_number):
     return tax_id_number[0] == "0"
 
 
+def tax_id_number_is_none_or_real_id_number(tax_id_number):
+    return tax_id_number is None or not tax_id_number_is_test_id_number(tax_id_number)
+
+
+def tax_id_number_is_none_or_test_id_number(tax_id_number):
+    return tax_id_number is None or tax_id_number_is_test_id_number(tax_id_number)
+
+
 def request_needs_testmerker(request_id):
     if request_id in NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION:
         get_list_vast_requests.cache_clear()

--- a/scripts/list_permits.py
+++ b/scripts/list_permits.py
@@ -2,7 +2,6 @@ import os
 
 import click
 
-from erica import get_settings
 from erica.worker.jobs.list_permission_jobs import get_idnr_status_list_with_huey, get_idnr_status_list
 
 
@@ -13,13 +12,9 @@ from erica.worker.jobs.list_permission_jobs import get_idnr_status_list_with_hue
 @click.option('--end_date')
 @click.option('--show_xml')
 @click.option('--use_huey')
-def main(idnr=None, status=None, start_date=None, end_date=None, show_xml=False, use_huey=None):
-    if not use_huey:
-        use_huey = get_settings().run_with_huey
+def main(idnr=None, status=None, start_date=None, end_date=None, show_xml=False, use_huey=False):
     if use_huey:
-        result = get_idnr_status_list_with_huey(idnr, status, start_date, end_date, show_xml)
-
-        return result(blocking=True, timeout=10)
+        return get_idnr_status_list_with_huey(idnr, status, start_date, end_date, show_xml)
     return get_idnr_status_list(idnr, status, start_date, end_date, show_xml)
 
 

--- a/scripts/list_permits.py
+++ b/scripts/list_permits.py
@@ -2,6 +2,7 @@ import os
 
 import click
 
+from erica import get_settings
 from erica.worker.jobs.list_permission_jobs import get_idnr_status_list_with_huey, get_idnr_status_list
 
 
@@ -12,9 +13,13 @@ from erica.worker.jobs.list_permission_jobs import get_idnr_status_list_with_hue
 @click.option('--end_date')
 @click.option('--show_xml')
 @click.option('--use_huey')
-def main(idnr=None, status=None, start_date=None, end_date=None, show_xml=False, use_huey=False):
+def main(idnr=None, status=None, start_date=None, end_date=None, show_xml=False, use_huey=None):
+    if not use_huey:
+        use_huey = get_settings().run_with_huey
     if use_huey:
-        return get_idnr_status_list_with_huey(idnr, status, start_date, end_date, show_xml)
+        result = get_idnr_status_list_with_huey(idnr, status, start_date, end_date, show_xml)
+
+        return result(blocking=True, timeout=10)
     return get_idnr_status_list(idnr, status, start_date, end_date, show_xml)
 
 

--- a/tests/api/dto/test_grundsteuer_input_eigentuemer.py
+++ b/tests/api/dto/test_grundsteuer_input_eigentuemer.py
@@ -100,11 +100,11 @@ class TestEigentuemer:
                           steuer_id="03352417692", anteil=Anteil(zaehler="1", nenner="2"))]
         Eigentuemer.parse_obj({"person": persons})
 
-    def test_if_all_persons_have_test_tax_id_number_not_special_testmerker_then_raise_error(self):
+    def test_if_all_persons_have_test_tax_id_number_or_none_then_raise_no_error(self):
         persons = [Person(persoenliche_angaben=PersoenlicheAngaben(anrede="frau", name="daViella",
                                                                    vorname="Gruella"),
                           adresse=Adresse(plz="79618", ort="Rheinfelden"),
-                          steuer_id="10796522382", anteil=Anteil(zaehler="1", nenner="2")),
+                          anteil=Anteil(zaehler="1", nenner="2")),
                    Person(persoenliche_angaben=PersoenlicheAngaben(anrede="herr", name="Man",
                                                                    vorname="Robin"),
                           adresse=Adresse(plz="79618", ort="Rheinfelden"),
@@ -113,14 +113,28 @@ class TestEigentuemer:
                                                                    vorname="Bella"),
                           adresse=Adresse(plz="79618", ort="Rheinfelden"),
                           steuer_id="01153694820", anteil=Anteil(zaehler="1", nenner="2"))]
-        with pytest.raises(ValidationError):
-            Eigentuemer.parse_obj({"person": persons})
+        Eigentuemer.parse_obj({"person": persons})
 
     def test_if_all_persons_have_real_tax_id_number_then_raise_no_error(self):
         persons = [Person(persoenliche_angaben=PersoenlicheAngaben(anrede="frau", name="daViella",
                                                                    vorname="Gruella"),
                           adresse=Adresse(plz="79618", ort="Rheinfelden"),
                           steuer_id="10796522382", anteil=Anteil(zaehler="1", nenner="2")),
+                   Person(persoenliche_angaben=PersoenlicheAngaben(anrede="herr", name="Man",
+                                                                   vorname="Robin"),
+                          adresse=Adresse(plz="79618", ort="Rheinfelden"),
+                          steuer_id="38689804274", anteil=Anteil(zaehler="1", nenner="2")),
+                   Person(persoenliche_angaben=PersoenlicheAngaben(anrede="frau", name="Biest",
+                                                                   vorname="Bella"),
+                          adresse=Adresse(plz="79618", ort="Rheinfelden"),
+                          steuer_id="43865766025", anteil=Anteil(zaehler="1", nenner="2"))]
+        Eigentuemer.parse_obj({"person": persons})
+
+    def test_if_all_persons_have_real_tax_id_number_or_none_then_raise_no_error(self):
+        persons = [Person(persoenliche_angaben=PersoenlicheAngaben(anrede="frau", name="daViella",
+                                                                   vorname="Gruella"),
+                          adresse=Adresse(plz="79618", ort="Rheinfelden"),
+                          anteil=Anteil(zaehler="1", nenner="2")),
                    Person(persoenliche_angaben=PersoenlicheAngaben(anrede="herr", name="Man",
                                                                    vorname="Robin"),
                           adresse=Adresse(plz="79618", ort="Rheinfelden"),


### PR DESCRIPTION
# Short Description
- Eigentümer with no SteuerID should now pass validation.
- One test case, `test_if_all_persons_have_test_tax_id_number_not_special_testmerker_then_raise_error`, did not seem to be doing what it claimed to and was equivalent to another test case further down, so I appropriated it to define a new test case.