### PR TITLE
Install pcsc from debian testing (bookworm).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV ELSTER_DATENLIEFERANT=$elster_datenlieferant
 ENV ELSTER_HERSTELLER_ID=$elster_hersteller_id
 
 WORKDIR /app
-RUN echo "APT::Default-Release \"bullseye\";" >> /etc/apt/apt.conf.d/default-release && \
+RUN echo "Package: *\nPin: release n=bookworm\nPin-Priority: 50\n" >> /etc/apt/preferences && \
     echo "deb http://ftp.debian.org/debian bookworm main" >> /etc/apt/sources.list.d/bookworm.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y -t bookworm pcsc-tools pcscd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@ ENV ELSTER_DATENLIEFERANT=$elster_datenlieferant
 ENV ELSTER_HERSTELLER_ID=$elster_hersteller_id
 
 WORKDIR /app
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y pcsc-tools pcscd procps unzip curl && \
+RUN echo "APT::Default-Release \"bullseye\";" >> /etc/apt/apt.conf.d/default-release && \
+    echo "deb http://ftp.debian.org/debian bookworm main" >> /etc/apt/sources.list.d/bookworm.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y -t bookworm pcsc-tools pcscd && \
+    apt-get install --no-install-recommends -y procps unzip curl && \
     rm -rf /var/lib/apt/lists/* && \
     curl https://dbs-download.obs.otc.t-systems.com/rds/ca-bundle.pem -o /opt/rds-ca-bundle.pem
 


### PR DESCRIPTION
# Short Description
Upgrades [pcscd](https://packages.debian.org/bookworm/pcscd) and [pcsd-tools](https://packages.debian.org/bookworm/pcsc-tools) from bullseye (current debian stable) to bookworm (current debian testing). This is an attempt to fix the underlying issue that triggers the mysterious ERIC_CRYPT_E_SC_SLOT_EMPTY error.

# Changes
- Adds the bookworm repository to apt sources.
- Installs pcscd and pcsc-tools from bookworm. Apart from these two and their dependencies (see links above for the list), sources of the rest of the packages should remain unchanged (i.e. bullseye).

